### PR TITLE
v1.3.0. Include threshold checker and re-enable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ gulp.task('coverage', function (cb) {
 		.pipe(injectModules())
 		.pipe(mocha())
 		.pipe(babelIstanbul.writeReports())
+    .pipe(babelIstanbul.enforceThresholds({ thresholds: { global: 90 } }))
 		.on('end', cb);
 	});
 });
@@ -236,12 +237,61 @@ See also:
 
 ### istanbul.enforceThresholds(opt)
 
-This was disabled in v1.0.0 because it used [istanbul-threshold-checker][istanbul-threshold-checker]
-v0.1.0 which used Istanbul v0.3.x. The Handlebars helpers used by this old version of Istanbul's
-reporters would override the helpers defined by babel-istanbul. Obviously that's not good.
+Checks coverage against minimum acceptable thresholds. Fails the build if any of the thresholds are not met.
 
-For now, it just acts a passthrough. It has no effect. This full functionality may
-return someday. PRs welcome.
+#### opt
+Type: `Object` (optional)
+```js
+{
+  coverageVariable: 'someVariable',
+  thresholds: {
+    global: 60,
+    each: -10
+  }
+}
+```
+
+##### coverageVariable
+Type: `String` (optional)
+Default: `'$$cov_' + new Date().getTime() + '$$'`
+
+The global variable istanbul uses to store coverage
+
+
+##### thresholds
+Type: `Object` (required)
+
+Minimum acceptable coverage thresholds. Any coverage values lower than the specified threshold will fail the build.
+
+Each threshold value can be:
+- A positive number - used as a percentage
+- A negative number - used as the maximum amount of coverage gaps
+- A falsey value will skip the coverage
+
+Thresholds can be specified across all files (`global`) or per file (`each`):
+```
+{
+  global: 80,
+  each: 60
+}
+```
+
+You can also specify a value for each metric:
+```
+{
+  global: {
+    statements: 80,
+    branches: 90,
+    lines: 70,
+    functions: -10
+  }
+  each: {
+    statements: 100,
+    branches: 70,
+    lines: -20
+  }
+}
+```
 
 #### emits
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var _ = require('lodash');
 var Report = istanbul.Report;
 var Collector = istanbul.Collector;
 var PluginError = gutil.PluginError;
-// var checker = require('istanbul-threshold-checker');
+var checker = require('./threshold-checker');
 
 var PLUGIN_NAME = 'gulp-babel-istanbul';
 var COVERAGE_VARIABLE = '$$cov_' + new Date().getTime() + '$$';
@@ -133,11 +133,6 @@ plugin.writeReports = function (opts) {
   return cover;
 };
 
-plugin.enforceThresholds = function () {
-  return through().resume();
-};
-
-/*
 plugin.enforceThresholds = function (opts) {
   opts = opts || {};
   opts = _.defaults(opts, {
@@ -168,4 +163,3 @@ plugin.enforceThresholds = function (opts) {
 
   return cover;
 };
-*/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-babel-istanbul",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Babel + Istanbul unit test coverage plugin for gulp.",
   "keywords": [
     "gulpplugin",

--- a/test/main.js
+++ b/test/main.js
@@ -377,7 +377,7 @@ describe('gulp-babel-istanbul', function () {
       rimraf.sync('cov-foo');
     });
 
-    it.skip('checks coverage fails against global threshold', function (done) {
+    it('checks coverage fails against global threshold', function (done) {
       var resolved = false;
 
       process.stdout.write = function () {};
@@ -401,7 +401,7 @@ describe('gulp-babel-istanbul', function () {
         });
     });
 
-    it.skip('checks coverage fails against per file threshold', function (done) {
+    it('checks coverage fails against per file threshold', function (done) {
       var resolved = false;
 
       process.stdout.write = function () {};
@@ -425,7 +425,7 @@ describe('gulp-babel-istanbul', function () {
         });
     });
 
-    it.skip('checks coverage passes against global and per file thresholds', function (done) {
+    it('checks coverage passes against global and per file thresholds', function (done) {
       var resolved = false;
 
       process.stdout.write = function () {};
@@ -448,7 +448,7 @@ describe('gulp-babel-istanbul', function () {
         });
     });
 
-    it.skip('checks coverage with a custom coverage variable', function (done) {
+    it('checks coverage with a custom coverage variable', function (done) {
       var resolved = false;
       var coverageVariable = 'CUSTOM_COVERAGE_VARIABLE';
 

--- a/test/threshold-checker.js
+++ b/test/threshold-checker.js
@@ -1,0 +1,248 @@
+'use strict';
+
+/*
+The MIT License (MIT)
+
+Copyright (c) 2015 Peter West
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+https://github.com/peterjwest/istanbul-threshold-checker
+*/
+
+var assert = require('assert');
+var checker = require('../threshold-checker');
+var istanbul = require('babel-istanbul');
+
+describe('threshold-checker', function() {
+  describe('checkThreshold', function() {
+  	it('checks percentage threshold passes', function() {
+  		var coverage = { total: 125, covered: 75, skipped: 0, pct: 60 };
+  		assert.deepEqual(checker.checkThreshold(60, coverage), { failed: false, value: 60 });
+  	});
+
+  	it('checks percentage threshold fails', function() {
+  		var coverage = { total: 125, covered: 75, skipped: 0, pct: 60 };
+  		assert.deepEqual(checker.checkThreshold(80, coverage), { failed: true, value: 60 });
+  	});
+
+  	it('checks gap threshold passes', function() {
+  		var coverage = { total: 50, covered: 40, skipped: 0, pct: 80 };
+  		assert.deepEqual(checker.checkThreshold(-10, coverage), { failed: false, value: -10 });
+  	});
+
+  	it('checks gap threshold fails', function() {
+  		var coverage = { total: 50, covered: 40, skipped: 0, pct: 80 };
+  		assert.deepEqual(checker.checkThreshold(-5, coverage), { failed: true, value: -10 });
+  	});
+
+  	it('skips thresholds which are false', function() {
+  		var coverage = { total: 50, covered: 40, skipped: 0, pct: 80 };
+  		var expected = { failed: false, skipped: true };
+  		assert.deepEqual(checker.checkThreshold(null, coverage), expected);
+  		assert.deepEqual(checker.checkThreshold(undefined, coverage), expected);
+  		assert.deepEqual(checker.checkThreshold(false, coverage), expected);
+  		assert.deepEqual(checker.checkThreshold(0, coverage), expected);
+  	});
+  });
+
+  describe('checkThresholds', function() {
+  	it('checks all thresholds', function() {
+  		var thresholds = { lines: -20, statements: 60, functions: -50, branches: 66 };
+  		var coverage = {
+  			lines: { total: 100, covered: 90, skipped: 0, pct: 90 },
+  			statements: { total: 120, covered: 60, skipped: 0, pct: 50 },
+  			functions: { total: 80, covered: 20, skipped: 0, pct: 25 },
+  			branches: { total: 90, covered: 60, skipped: 0, pct: 66.67 }
+  		};
+
+  		assert.deepEqual(checker.checkThresholds(thresholds, coverage), [
+  			{ value: -10, failed: false },
+  			{ value: 50, failed: true },
+  			{ value: -60, failed: true },
+  			{ value: 66.67, failed: false }
+  		]);
+  	});
+
+  	it('checks all thresholds in the same order, regardless of the coverage object', function() {
+  		var thresholds = { lines: -20, statements: 60, functions: -50, branches: 66 };
+  		var coverage = {
+  			statements: { total: 120, covered: 60, skipped: 0, pct: 50 },
+  			functions: { total: 80, covered: 20, skipped: 0, pct: 25 },
+  			lines: { total: 100, covered: 90, skipped: 0, pct: 90 },
+  			branches: { total: 90, covered: 60, skipped: 0, pct: 66.67 }
+  		};
+
+  		assert.deepEqual(checker.checkThresholds(thresholds, coverage), [
+  			{ value: -10, failed: false },
+  			{ value: 50, failed: true },
+  			{ value: -60, failed: true },
+  			{ value: 66.67, failed: false }
+  		]);
+  	});
+
+  	it('checks thresholds using a single value', function() {
+  		var thresholds = 60;
+  		var coverage = {
+  			lines: { total: 100, covered: 90, skipped: 0, pct: 90 },
+  			statements: { total: 120, covered: 60, skipped: 0, pct: 50 },
+  			functions: { total: 80, covered: 20, skipped: 0, pct: 25 },
+  			branches: { total: 90, covered: 60, skipped: 0, pct: 66.67 }
+  		};
+
+  		assert.deepEqual(checker.checkThresholds(thresholds, coverage), [
+  			{ value: 90, failed: false },
+  			{ value: 50, failed: true },
+  			{ value: 25, failed: true },
+  			{ value: 66.67, failed: false }
+  		]);
+  	});
+  });
+
+  describe('checkFailures', function() {
+  	beforeEach(function() {
+      this.env = {
+        summarizeCoverage: istanbul.utils.summarizeCoverage,
+        summarizeFileCoverage: istanbul.utils.summarizeFileCoverage,
+      };
+
+  		istanbul.utils.summarizeCoverage = function () {
+        return {
+    			lines: { total: 100, covered: 90, skipped: 0, pct: 90 },
+    			statements: { total: 120, covered: 60, skipped: 0, pct: 50 },
+    			functions: { total: 80, covered: 20, skipped: 0, pct: 25 },
+    			branches: { total: 90, covered: 60, skipped: 0, pct: 66.67 }
+        };
+  		};
+
+  		istanbul.utils.summarizeFileCoverage = (function () {
+        var calls = 0;
+
+        return function () {
+          switch (calls++) {
+            case 0:
+              return {
+                lines: { total: 100, covered: 80, skipped: 0, pct: 80 },
+                statements: { total: 120, covered: 120, skipped: 0, pct: 100 },
+                functions: { total: 80, covered: 80, skipped: 0, pct: 100 },
+                branches: { total: 90, covered: 90, skipped: 0, pct: 100 }
+              };
+            default:
+              return {
+                lines: { total: 100, covered: 90, skipped: 0, pct: 90 },
+                statements: { total: 120, covered: 60, skipped: 0, pct: 50 },
+                functions: { total: 80, covered: 20, skipped: 0, pct: 25 },
+                branches: { total: 90, covered: 90, skipped: 0, pct: 100 }
+              };
+          }
+        };
+      }());
+
+  		this.coverage = {
+  			'/file/test.js': {},
+  			'/file/test2.js': {}
+  		};
+  	});
+
+  	afterEach(function() {
+  		istanbul.utils.summarizeCoverage = this.env.summarizeCoverage;
+      istanbul.utils.summarizeFileCoverage = this.env.summarizeFileCoverage;
+  	});
+
+  	it('checks global and per file thresholds', function() {
+  		var thresholds = {
+  			global: { lines: 90, statements: 100, functions: 100, branches: 100 },
+  			each: { lines: 100, statements: 100, functions: 100, branches: 100 }
+  		};
+
+  		assert.deepEqual(checker.checkFailures(thresholds, this.coverage), [
+  			{
+  				type: 'lines',
+  				global: { failed: false, value: 90 },
+  				each: { failed: true, failures: ['/file/test.js', '/file/test2.js'] }
+  			}, {
+  				type: 'statements',
+  				global: { failed: true, value: 50 },
+  				each: { failed: true, failures: ['/file/test2.js'] }
+  			}, {
+  				type: 'functions',
+  				global: { failed: true, value: 25 },
+  				each: { failed: true, failures: ['/file/test2.js'] }
+  			}, {
+  				type: 'branches',
+  				global: { failed: true, value: 66.67 },
+  				each: { failed: false, failures: [] }
+  			}
+  		]);
+  	});
+
+  	it('checks simple thresholds', function() {
+  		var thresholds = {
+  			each: 90,
+  			global: 80
+  		};
+
+  		assert.deepEqual(checker.checkFailures(thresholds, this.coverage), [
+  			{
+  				type: 'lines',
+  				global: { failed: false, value: 90 },
+  				each: { failed: true, failures: ['/file/test.js'] }
+  			}, {
+  				type: 'statements',
+  				global: { failed: true, value: 50 },
+  				each: { failed: true, failures: ['/file/test2.js'] }
+  			}, {
+  				type: 'functions',
+  				global: { failed: true, value: 25 },
+  				each: { failed: true, failures: ['/file/test2.js'] }
+  			}, {
+  				type: 'branches',
+  				global: { failed: true, value: 66.67 },
+  				each: { failed: false, failures: [] }
+  			}
+  		]);
+  	});
+
+  	it('checks only global thresholds', function() {
+  		var thresholds = {
+  			global: { lines: 90, statements: 100, functions: 100, branches: 100 }
+  		};
+
+  		assert.deepEqual(checker.checkFailures(thresholds, this.coverage), [
+  			{ type: 'lines', global: { failed: false, value: 90 } },
+  			{ type: 'statements', global: { failed: true, value: 50 } },
+  			{ type: 'functions', global: { failed: true, value: 25 } },
+  			{ type: 'branches', global: { failed: true, value: 66.67 } }
+  		]);
+  	});
+
+  	it('checks only per file thresholds', function() {
+  		var thresholds = {
+  			each: { lines: 90, statements: 100, functions: 100, branches: 100 }
+  		};
+
+  		assert.deepEqual(checker.checkFailures(thresholds, this.coverage), [
+  			{ type: 'lines', each: { failed: true, failures: ['/file/test.js'] } },
+  			{ type: 'statements', each: { failed: true, failures: ['/file/test2.js'] } },
+  			{ type: 'functions', each: { failed: true, failures: ['/file/test2.js'] } },
+  			{ type: 'branches', each: { failed: false, failures: [] } }
+  		]);
+  	});
+  });
+});

--- a/threshold-checker.js
+++ b/threshold-checker.js
@@ -1,0 +1,105 @@
+'use strict';
+
+/*
+The MIT License (MIT)
+
+Copyright (c) 2015 Peter West
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+https://github.com/peterjwest/istanbul-threshold-checker
+*/
+
+var _ = require('lodash');
+var utils = require('babel-istanbul').utils;
+
+var TYPES = ['lines', 'statements', 'functions', 'branches'];
+
+var checker = module.exports = {
+  checkThreshold: function(threshold, summary) {
+    var result = { failed: false };
+
+    // Check for no threshold
+    if (!threshold) {
+      result.skipped = true;
+      return result;
+    }
+
+    // Check percentage threshold
+    if (threshold > 0) {
+      result.value = summary.pct;
+      result.failed = result.value < threshold;
+    }
+    // Check gap threshold
+    else {
+      result.value = summary.covered - summary.total;
+      result.failed = result.value < threshold;
+    }
+
+    return result;
+  },
+
+  checkThresholds: function(thresholds, summary) {
+    return TYPES.map(function(type) {
+      // If the threshold is a number use it, otherwise lookup the threshold type
+      var threshold = typeof thresholds === 'number' ? thresholds : thresholds && thresholds[type];
+      return checker.checkThreshold(threshold, summary[type]);
+    });
+  },
+
+  checkFailures: function(thresholds, coverage) {
+    var summary = TYPES.map(function(type) {
+      return { type: type };
+    });
+
+    // If there are global thresholds check overall coverage
+    if (thresholds.global) {
+      var global = checker.checkThresholds(thresholds.global, utils.summarizeCoverage(coverage));
+      // Inject into summary
+      summary.map(function(metric, i) {
+        metric.global = global[i];
+      });
+    }
+
+    // If there are individual thresholds check coverage per file
+    if (thresholds.each) {
+      var failures = { statements: [], branches: [], lines: [], functions: [] };
+      _.each(coverage, function(fileCoverage, filename) {
+        // Check failures for a file
+        var each = checker.checkThresholds(
+          thresholds.each,
+          utils.summarizeFileCoverage(fileCoverage)
+        );
+        _.map(each, function(item, i) {
+          if (item.failed) failures[TYPES[i]].push(filename);
+        });
+      });
+
+      // Inject into summary
+      summary.map(function(metric) {
+        metric.each = {
+          failed: failures[metric.type].length > 0,
+          failures: failures[metric.type]
+        };
+      });
+    }
+
+    return summary;
+  }
+};


### PR DESCRIPTION
I opened [this PR](https://github.com/peterjwest/istanbul-threshold-checker/pull/2) in [istanbul-threshold-checker](https://github.com/peterjwest/istanbul-threshold-checker) to resolve the HBS template issue.

However, given the apparent stagnation of that project (no new commits, PR with no comments for almost a year) it seems unlikely that it will be merged and published.

This PR merges the work from that repo into `gulp-babel-istanbul`. It was a fairly small bit of code and did not require any additional dependencies so this seemed like the most reasonable approach to me. However, if you would prefer to keep it separate from this project, I would be happy to fork and publish under a different name.

Deltas between this an `istanbul-threshold-checker`:
1. Tab indentation converted to two-spaces to match the style in this repo.
2. Added `use strict` to the top of the files.
3. Added license attribution.
4. Swapped `istanbul` for `babel-istanbul` to access `object-utils`.
5. Removed `sinon` dependency since it was only being used for a simple stub.

Cheers!
